### PR TITLE
Bugfix: Item Saving

### DIFF
--- a/LocalStorage/LocalStorage.cs
+++ b/LocalStorage/LocalStorage.cs
@@ -406,6 +406,12 @@ namespace LocalStorage
                             var file = ResolveLstore(asset);
                             File.Delete(file);
                         }
+                        var thumbnail = new Uri(record.ThumbnailURI);
+                        if (thumbnail.Scheme == "lstore")
+                        {
+                            var file = ResolveLstore(thumbnail);
+                            File.Delete(file);
+                        }
 
                         // this is not the smartest system,
                         // if a user manually creates a record that is in the wrong path and wrong name it could be bad

--- a/LocalStorage/LocalStorage.cs
+++ b/LocalStorage/LocalStorage.cs
@@ -409,7 +409,16 @@ namespace LocalStorage
 
                         // this is not the smartest system,
                         // if a user manually creates a record that is in the wrong path and wrong name it could be bad
-                        File.Delete(Path.Combine(REC_PATH, record.Path.Replace('\\', '/'), record.RecordId) + ".json");
+                        var path = Path.Combine(REC_PATH, record.Path.Replace('\\', '/'), record.RecordId) + ".json";
+                        if (File.Exists(path))
+                        {
+                            File.Delete(path);
+                        }
+                        else
+                        {
+                            path = Path.Combine(REC_PATH, record.Path.Replace('\\', '/'), record.Name) + ".json";
+                            File.Delete(path);
+                        }
                     }
                     __result = test;
                     return false;
@@ -455,7 +464,16 @@ namespace LocalStorage
                 }
                 if(dir.LinkRecord != null)
                 {
-                    File.Delete(Path.Combine(REC_PATH, dir.LinkRecord.Path.Replace('\\', '/'), dir.LinkRecord.RecordId) + ".json");
+                    var path = Path.Combine(REC_PATH, dir.LinkRecord.Path.Replace('\\', '/'), dir.LinkRecord.RecordId) + ".json";
+                    if (Directory.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+                    else
+                    {
+                        path = Path.Combine(REC_PATH, dir.LinkRecord.Path.Replace('\\', '/'), dir.LinkRecord.Name) + ".json";
+                        File.Delete(path);
+                    }
                 }
             }
         }

--- a/LocalStorage/LocalStorage.cs
+++ b/LocalStorage/LocalStorage.cs
@@ -266,8 +266,9 @@ namespace LocalStorage
 
                 if (__instance.OwnerId == LOCAL_OWNER)
                 {
+                    var recordId = SkyFrost.Base.RecordHelper.GenerateRecordID();
                     var fixedPath = __instance.ChildRecordPath.Replace('\\', '/');
-                    var savePath = Path.Combine(DATA_PATH, fixedPath, name);
+                    var savePath = Path.Combine(DATA_PATH, fixedPath, recordId);
                     var dataPath = savePath + ".json";
                     var thumbPath = savePath + Path.GetExtension(thumbnail.ToString());
 
@@ -300,18 +301,18 @@ namespace LocalStorage
                         thumbFile.Flush(); thumbFile.Dispose();
                     }
 
-                    var fileLocalPath = "lstore:///" + fixedPath + "/" + name + ".json";
-                    var thumbLocalPath = "lstore:///" + fixedPath + "/" + name + Path.GetExtension(thumbnail.ToString());
+                    var fileLocalPath = "lstore:///" + fixedPath + "/" + recordId + ".json";
+                    var thumbLocalPath = "lstore:///" + fixedPath + "/" + recordId + Path.GetExtension(thumbnail.ToString());
                     //var thumbLocalPath = thumbnail.ToString();
 
-                    var rec = SkyFrost.Base.RecordHelper.CreateForObject<Record>(name, __instance.OwnerId, fileLocalPath, thumbLocalPath);
+                    var rec = SkyFrost.Base.RecordHelper.CreateForObject<Record>(name, __instance.OwnerId, fileLocalPath, thumbLocalPath, recordId);
                     rec.Path = __instance.ChildRecordPath;
                     if (tags != null)
                     {
                         rec.Tags = new HashSet<string>(tags);
                     }
 
-                    var recPath = Path.Combine(REC_PATH, fixedPath, name + ".json");
+                    var recPath = Path.Combine(REC_PATH, fixedPath, recordId + ".json");
                     using (var fs = File.CreateText(recPath))
                     {
                         JsonSerializer serializer = new JsonSerializer();
@@ -358,11 +359,12 @@ namespace LocalStorage
             {
                 if (__instance.OwnerId == LOCAL_OWNER)
                 {
+                    var recordId = SkyFrost.Base.RecordHelper.GenerateRecordID();
                     var fixedPath = __instance.ChildRecordPath.Replace('\\', '/');
-                    Record record = SkyFrost.Base.RecordHelper.CreateForLink<Record>(name, __instance.OwnerId, target.ToString(), null);
+                    Record record = SkyFrost.Base.RecordHelper.CreateForLink<Record>(name, __instance.OwnerId, target.ToString(), recordId);
                     record.Path = __instance.ChildRecordPath;
 
-                    var recPath = Path.Combine(REC_PATH, fixedPath, name + ".json");
+                    var recPath = Path.Combine(REC_PATH, fixedPath, recordId + ".json");
                     using (var fs = File.CreateText(recPath))
                     {
                         JsonSerializer serializer = new JsonSerializer();
@@ -407,7 +409,7 @@ namespace LocalStorage
 
                         // this is not the smartest system,
                         // if a user manually creates a record that is in the wrong path and wrong name it could be bad
-                        File.Delete(Path.Combine(REC_PATH, record.Path.Replace('\\', '/'), record.Name) + ".json");
+                        File.Delete(Path.Combine(REC_PATH, record.Path.Replace('\\', '/'), record.RecordId) + ".json");
                     }
                     __result = test;
                     return false;
@@ -453,7 +455,7 @@ namespace LocalStorage
                 }
                 if(dir.LinkRecord != null)
                 {
-                    File.Delete(Path.Combine(REC_PATH, dir.LinkRecord.Path.Replace('\\', '/'), dir.LinkRecord.Name) + ".json");
+                    File.Delete(Path.Combine(REC_PATH, dir.LinkRecord.Path.Replace('\\', '/'), dir.LinkRecord.RecordId) + ".json");
                 }
             }
         }


### PR DESCRIPTION
Changes items handlers to use record IDs as the names of files instead of the item name. This fixes items with identical names from being overwritten on save (Issue #2) and allows items with special characters in its name to be saved.

Retains the ability to delete records named by their associated item's name as a fallback if it is not named by record ID.

However, naming causes the order of items to be fairly random rather than following any sensible sorting methods.
Ideally, this would be changed so that they are sorted by date to match how the normal cloud inventory works or possibly even match the selected sorting option from Better Inventory Browser if it is installed